### PR TITLE
Fix crazy indentation and properly recover from import

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
 }
 
 group = "net.stefanfuchs.jslt.intellij.language"
-version = "1.0.7"
+version = "1.0.8"
 
 repositories {
     mavenCentral()
@@ -24,7 +24,7 @@ dependencies {
 
 // See https://github.com/JetBrains/gradle-intellij-plugin/
 intellij {
-    version.set("2023.2")
+    version.set("2023.3")
     plugins.set(listOf("org.jetbrains.plugins.yaml"))
 }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,11 +1,11 @@
 plugins {
-    id("org.jetbrains.intellij") version "1.13.3"
-    kotlin("jvm") version "1.8.10"
+    id("org.jetbrains.intellij") version "1.15.0"
+    kotlin("jvm") version "1.9.10"
     id("org.jetbrains.grammarkit") version "2022.3.1"
 }
 
 group = "net.stefanfuchs.jslt.intellij.language"
-version = "1.0.6"
+version = "1.0.7"
 
 repositories {
     mavenCentral()
@@ -24,7 +24,7 @@ dependencies {
 
 // See https://github.com/JetBrains/gradle-intellij-plugin/
 intellij {
-    version.set("2023.1")
+    version.set("2023.2")
     plugins.set(listOf("org.jetbrains.plugins.yaml"))
 }
 
@@ -36,7 +36,7 @@ grammarKit {
     grammarKitRelease.set("2021.1.2")
 
     // Optionally provide an IntelliJ version to build the classpath for GenerateParser/GenerateLexer tasks
-    intellijRelease.set("231.8109.175")
+    intellijRelease.set("232.9559.62")
 }
 
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -99,7 +99,7 @@ tasks {
 
     patchPluginXml {
         sinceBuild.set("232")
-        untilBuild.set("233")
+        untilBuild.set("234")
         changeNotes.set("""
             Support idea from version 232 to 233
         """.trimIndent())

--- a/src/main/kotlin/net/stefanfuchs/jslt/intellij/language/JsltBlock.kt
+++ b/src/main/kotlin/net/stefanfuchs/jslt/intellij/language/JsltBlock.kt
@@ -33,7 +33,7 @@ open class JsltBlock internal constructor(
                 -> JsltBodyBlock(
                     node = child,
                     wrap = wrap,
-                    alignment = Alignment.createAlignment(),
+                    alignment = null,
                     spacingBuilder = spacingBuilder
                 )
 
@@ -45,7 +45,7 @@ open class JsltBlock internal constructor(
                     JsltBlock(
                         node = child,
                         wrap = wrap,
-                        alignment = Alignment.createAlignment(),
+                        alignment = null,
                         spacingBuilder = spacingBuilder
                     )
                 }

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -44,8 +44,7 @@
     <change-notes>
         <![CDATA[
             <ul>
-                <li>Update to support IntelliJ 231.*</li>
-                <li>Fix: object comprehensions were marked as syntax error</li>
+                <li>Update to support IntelliJ 232.*</li>
             </ul>
         ]]>
     </change-notes>


### PR DESCRIPTION
Addresses two issues.

**Crazy Indentation**
```
{
  "abc" : {
                   "def" : {
                                      "ghi" : "jkl"   
                                } 
               }
}
```

now becomes
```
{
  "abc" : {
     "def" : {
       "ghi" : "jkl"   
      } 
   }
}
```

**Recover from import**
```
import "../some/path" as myFunction

{
 "abc" : "def"
}
```

would highlight { with red underline and say it was not expected, because the import was not properly recovered. Adding `if` and `left curly` would at least recover import for those transformations that start with left curly or if.