### PR TITLE
Enable indent configuration in code style settings

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -7,7 +7,7 @@ plugins {
 }
 
 group = "net.stefanfuchs.jslt.intellij.language"
-version = "2.0.00"
+version = "2.0.01"
 
 repositories {
     mavenCentral()

--- a/src/main/kotlin/net/stefanfuchs/jslt/intellij/language/JsltLanguageCodeStyleSettingsProvider.kt
+++ b/src/main/kotlin/net/stefanfuchs/jslt/intellij/language/JsltLanguageCodeStyleSettingsProvider.kt
@@ -1,11 +1,14 @@
 package net.stefanfuchs.jslt.intellij.language
 
+import com.intellij.application.options.SmartIndentOptionsEditor
 import com.intellij.lang.Language
 import com.intellij.psi.codeStyle.CodeStyleSettingsCustomizable
 import com.intellij.psi.codeStyle.LanguageCodeStyleSettingsProvider
 
 class JsltLanguageCodeStyleSettingsProvider : LanguageCodeStyleSettingsProvider() {
     override fun getLanguage(): Language = JsltLanguage
+
+    override fun getIndentOptionsEditor() = SmartIndentOptionsEditor()
 
     override fun customizeSettings(consumer: CodeStyleSettingsCustomizable, settingsType: SettingsType) =
         when (settingsType) {
@@ -51,6 +54,8 @@ class JsltLanguageCodeStyleSettingsProvider : LanguageCodeStyleSettingsProvider(
                 consumer.showStandardOptions(
                     CodeStyleSettingsCustomizable.IndentOption.INDENT_SIZE.name,
                     CodeStyleSettingsCustomizable.IndentOption.CONTINUATION_INDENT_SIZE.name,
+                    CodeStyleSettingsCustomizable.IndentOption.TAB_SIZE.name,
+                    CodeStyleSettingsCustomizable.IndentOption.USE_TAB_CHARACTER.name,
                     CodeStyleSettingsCustomizable.IndentOption.USE_RELATIVE_INDENTS.name
                 )
             }

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -44,6 +44,7 @@
     <change-notes>
         <![CDATA[
             <ul>
+                <li>Expose indent options</li>
                 <li>Update to support IntelliJ 251.*</li>
             </ul>
         ]]>


### PR DESCRIPTION
  ## Changes

  Fixes indent configuration in JSLT code style settings by adding `SmartIndentOptionsEditor`.

  **Before:** Indent and spacing options were displayed in settings but didn't actually work - users couldn't configure indentation at all.

  **After:** Full indent configuration now works:
  - Indent size
  - Continuation indent size
  - Tab size
  - Tab vs spaces
  - Relative indents

